### PR TITLE
(SIMP-398) Eliminate all uses of lsb* facts

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,6 +9,7 @@ fixtures:
     simpcat: "git://github.com/simp/pupmod-simp-concat"
     openldap: "git://github.com/simp/pupmod-simp-openldap"
     pki: "git://github.com/simp/pupmod-simp-pki"
+    sssd: "git://github.com/simp/pupmod-simp-sssd"
     stdlib: "git://github.com/simp/puppetlabs-stdlib"
   symlinks:
     nscd: "#{source_dir}"

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,4 @@
+--log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
+--relative
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,90 @@
 ---
 language: ruby
+sudo: false
 cache: bundler
-rvm:
-    - 1.8.7
-    - 1.9.3
-    - 2.0.0
-    - 2.2.1
-install: bundle install
+before_script:
+  - bundle
+bundler_args: --without development system_tests
+before_install: rm Gemfile.lock || true
 script:
-    - 'bundle exec rake validate'
-    - 'bundle exec rake lint'
-    - 'bundle exec rake spec'
+  - bundle exec rake test
+notifications:
+  email: false
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.1
+env:
+  global:
+    - STRICT_VARIABLES=yes
+    - TRUSTED_NODE_DATA=yes
+  matrix:
+  # NOTE: `:environmentpath` was not supported before Puppet 3.5
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
+    - PUPPET_VERSION="~> 3.7.0"
+    - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.0.0"
+    - PUPPET_VERSION="~> 4.1.0"
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
-    allow_failures:
-        - rvm: 1.8.7
-        - rvm: 2.2.1
+  fast_finish: true
+  allow_failures:
+    - rvm: 1.8.7
+    - rvm: 2.1.0
+    - rvm: 2.2.1
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
+
+  exclude:
+  # Ruby 1.8.7
+  # - Ruby 1.8.7 & Puppet 4.X is impossibru
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.2.0"
+
+  # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
+  # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
+  # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+
+  # Ruby 2.1.0
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0"
+
+  # Ruby 2.2.1
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,92 @@
+This module has grown over time based on a range of contributions from
+people using it. If you follow these contributing guidelines your patch
+will likely make it into a release a little quicker.
+
+
 ## Contributing
 
-Please refer to the main [SIMP Project Contributing Guide](https://github.com/NationalSecurityAgency/SIMP/blob/master/CONTRIBUTING.md)
-for details on contributing to this project.
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, and
+   it's great to know that you have a clean slate.
+
+3. Add a test for your change. Only refactoring and documentation
+   changes require no new tests. If you are adding functionality
+   or fixing a bug, please add a test.
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+
+## Dependencies
+
+The testing and development tools have a bunch of dependencies,
+all managed by [Bundler](http://bundler.io/) according to the
+[Puppet support matrix](http://docs.puppetlabs.com/guides/platforms.html#ruby-versions).
+
+By default the tests use a baseline version of Puppet.
+
+If you have Ruby 2.x or want a specific version of Puppet,
+you must set an environment variable such as:
+
+    export PUPPET_VERSION="~> 3.2.0"
+
+Install the dependencies like so...
+
+    bundle install
+
+## Syntax and style
+
+The test suite will run [Puppet Lint](http://puppet-lint.com/) and
+[Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
+check various syntax and style things. You can run these locally with:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+
+## Running the unit tests
+
+The unit test suite covers most of the code, as mentioned above please
+add tests if you're adding new functionality. If you've not used
+[rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
+about how best to test your new feature. Running the test suite is done
+with:
+
+    bundle exec rake spec
+
+Note also you can run the syntax, style and unit tests in one go with:
+
+    bundle exec rake test
+
+### Automatically run the tests
+
+During development of your puppet module you might want to run your unit
+tests a couple of times. You can use the following command to automate
+running the unit tests on every change made in the manifests folder.
+
+    bundle exec guard
+
+## Integration tests
+
+The unit tests just check the code runs, not that it does exactly what
+we want on a real machine. For that we're using
+[Beaker](https://github.com/puppetlabs/beaker).
+
+Beaker fires up a new virtual machine (using Vagrant) and runs a series of
+simple tests against it after applying the module. You can run our
+Beaker tests with:
+
+    bundle exec rake acceptance
+
+This will use the host described in `spec/acceptance/nodeset/default.yml`
+by default. To run against another host, set the `BEAKER_set` environment
+variable to the name of a host described by a `.yml` file in the
+`nodeset` directory. For example, to run against CentOS 6.4:
+
+    BEAKER_set=centos-64-x64 bundle exec rake acceptance
+
+If you don't want to have to recreate the virtual machine every time you
+can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will
+at least need `BEAKER_provision` set to yes (the default). The Vagrantfile
+for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.

--- a/Gemfile
+++ b/Gemfile
@@ -1,23 +1,52 @@
-# Environment variables:
+# Variables:
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
+group :test do
+  gem "rake"
+  gem 'puppet', puppetversion
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet"
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "simp-rspec-puppet-facts"
 
-gem 'puppet', puppetversion
-gem 'puppet-lint'
-gem 'puppetlabs_spec_helper'
-gem 'puppet_module_spec_helper'
-gem 'simp-rake-helpers'
+  # dependency hacks:
+  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
-group :debug do
-    gem 'pry'
-    gem 'pry-doc'
-    gem 'rspec'
-    gem 'mocha'
-    gem 'metadata-json-lint'
+  # simp-rake-helpers does not suport puppet 2.7.X
+  if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
+      # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
+      # TODO: fix upstream deps (parallel in simp-rake-helpers)
+      RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
+    gem 'simp-rake-helpers'
+  end
+end
+
+group :development do
+  gem "travis"
+  gem "travis-lint"
+  gem "vagrant-wrapper"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
+  gem 'pry'
+  gem 'pry-doc'
+end
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
+
+  # 1.0.5 introduces FIPS-first acc tests
+  gem 'simp-beaker-helpers', '>= 1.0.5'
+
+  # dependency hacks:
+  # NOTE: Workaround because net-ssh 2.10 is busting beaker
+  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
+  gem 'net-ssh', '~> 2.9.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,28 +1,68 @@
-#!/usr/bin/rake -T
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet/version'
+require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet-lint/tasks/puppet-lint'
 
-# For playing nice with mock
-File.umask(027)
+# These gems aren't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
 
-require 'simp/rake/pkg'
+
+# Lint & Syntax exclusions
+exclude_paths = [
+  "bundle/**/*",
+  "pkg/**/*",
+  "dist/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetSyntax.exclude_paths = exclude_paths
+
+# See: https://github.com/rodjek/puppet-lint/pull/397
+Rake::Task[:lint].clear
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = PuppetLint.configuration.ignore_paths
+end
 
 begin
-  require 'puppetlabs_spec_helper/rake_tasks'
+  require 'simp/rake/pkg'
+  Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
+    t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+  end
 rescue LoadError
-  puts "== WARNING: Gem puppetlabs_spec_helper not found, spec tests cannot be run! =="
+  puts "== WARNING: Gem simp-rake-helpers not found, pkg: tasks cannot be run! =="
 end
 
-# Lint Material
 begin
-  require 'puppet-lint/tasks/puppet-lint'
-
-  PuppetLint.configuration.send("disable_80chars")
-  PuppetLint.configuration.send("disable_variables_not_enclosed")
-  PuppetLint.configuration.send("disable_class_parameter_defaults")
-  PuppetLint.configuration.send("disable_selector_inside_resource")
+  require 'simp/rake/beaker'
+  Simp::Rake::Beaker.new( File.dirname( __FILE__ ) )
 rescue LoadError
-  puts "== WARNING: Gem puppet-lint not found, lint tests cannot be run! =="
+  # Ignoring this for now since all of these are currently convenience methods.
 end
 
-Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
-  t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
 end
+
+desc "Populate CONTRIBUTORS file"
+task :contributors do
+  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
+end
+
+task :metadata do
+  sh "metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+  :metadata,
+]

--- a/build/pupmod-nscd.spec
+++ b/build/pupmod-nscd.spec
@@ -6,7 +6,6 @@ License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
-Requires: pupmod-common >= 4.1.0-6
 Requires: pupmod-simplib >= 1.0.0-0
 Requires: pupmod-simpcat >= 4.0.0-0
 Requires: pupmod-openldap >= 4.1.0-3

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -20,12 +20,6 @@ class nscd::group (
 ) {
   include 'nscd'
 
-  $svc_name = 'group'
-
-  concat_fragment { "nscd+conf.$svc_name":
-    content => template('nscd/nscd.service.erb')
-  }
-
   validate_array_member($enable_cache,['yes','no'])
   validate_integer($positive_ttl)
   validate_integer($negative_ttl)
@@ -35,4 +29,9 @@ class nscd::group (
   validate_array_member($shared,['yes','no'])
   validate_integer($max_db_size)
   validate_array_member($auto_propogate,['yes','no'])
+
+  $svc_name = 'group'
+  concat_fragment { "nscd+conf.${svc_name}":
+    content => template('nscd/nscd.service.erb')
+  }
 }

--- a/manifests/hosts.pp
+++ b/manifests/hosts.pp
@@ -19,12 +19,6 @@ class nscd::hosts(
 ) {
   include 'nscd'
 
-  $svc_name = 'hosts'
-
-  concat_fragment { "nscd+conf.$svc_name":
-    content => template('nscd/nscd.service.erb')
-  }
-
   validate_array_member($enable_cache,['yes','no'])
   validate_integer($positive_ttl)
   validate_integer($negative_ttl)
@@ -33,4 +27,9 @@ class nscd::hosts(
   validate_array_member($persistent,['yes','no'])
   validate_array_member($shared,['yes','no'])
   validate_integer($max_db_size)
+
+  $svc_name = 'hosts'
+  concat_fragment { "nscd+conf.${svc_name}":
+    content => template('nscd/nscd.service.erb')
+  }
 }

--- a/manifests/passwd.pp
+++ b/manifests/passwd.pp
@@ -20,12 +20,6 @@ class nscd::passwd (
 ) {
   include 'nscd'
 
-  $svc_name = 'passwd'
-
-  concat_fragment { "nscd+conf.$svc_name":
-    content => template('nscd/nscd.service.erb')
-  }
-
   validate_array_member($enable_cache,['yes','no'])
   validate_integer($positive_ttl)
   validate_integer($negative_ttl)
@@ -35,4 +29,10 @@ class nscd::passwd (
   validate_array_member($shared,['yes','no'])
   validate_integer($max_db_size)
   validate_array_member($auto_propogate,['yes','no'])
+
+  $svc_name = 'passwd'
+
+  concat_fragment { "nscd+conf.${svc_name}":
+    content => template('nscd/nscd.service.erb')
+  }
 }

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -19,12 +19,6 @@ class nscd::services (
 ) {
   include 'nscd'
 
-  $svc_name = 'services'
-
-  concat_fragment { "nscd+conf.$svc_name":
-    content => template('nscd/nscd.service.erb')
-  }
-
   validate_array_member($enable_cache,['yes','no'])
   validate_integer($positive_ttl)
   validate_integer($negative_ttl)
@@ -33,4 +27,10 @@ class nscd::services (
   validate_array_member($persistent,['yes','no'])
   validate_array_member($shared,['yes','no'])
   validate_integer($max_db_size)
+
+  $svc_name = 'services'
+
+  concat_fragment { "nscd+conf.${svc_name}":
+    content => template('nscd/nscd.service.erb')
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,45 @@
+{
+  "name":    "simp-nscd",
+  "version": "5.0.0",
+  "author":  "simp",
+  "summary": "manages NSCD",
+  "license": "Apache-2.0",
+  "source":  "https://github.com/simp/pupmod-simp-nscd",
+  "project_page": "https://github.com/simp/pupmod-simp-nscd",
+  "issues_url":   "https://simp-project.atlassian.net",
+  "tags": [ "simp", "nscd", "ldap", "caching" ],
+  "dependencies": [
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 4.0.0"
+    },
+    {
+      "name": "simp-openldap",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-simpcat",
+      "version_requirement": ">= 4.0.0"
+    },
+    {
+      "name": "simp-simplib",
+      "version_requirement": ">= 1.0.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ]
+}

--- a/spec/classes/group_spec.rb
+++ b/spec/classes/group_spec.rb
@@ -1,28 +1,28 @@
 require 'spec_helper'
 
 describe 'nscd::group' do
-  let(:facts) {{
-    :fqdn => 'test.host.net',
-    :hardwaremodel => 'x86_64',
-    :operatingsystem => 'RedHat',
-    :lsbmajdistrelease => '7',
-    :apache_version => '2.4',
-    :grub_version => '0.9',
-    :uid_min => '500'
-  }}
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
 
-  it { should create_class('nscd') }
-  it { should create_class('nscd::group') }
+        it { is_expected.to create_class('nscd::group') }
+        it { is_expected.to create_class('nscd') }
 
-  context 'base' do
-    it { should compile.with_all_deps }
-    it { should create_concat_fragment('nscd+conf.group').with({
-        :content => /enable-cache\s+group\s+yes/
-      })
-    }
-    it { should create_concat_fragment('nscd+conf.group').with({
-        :content => /auto-propagate/
-      })
-    }
+        context 'base' do
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_concat_fragment('nscd+conf.group').with({
+              :content => /enable-cache\s+group\s+yes/
+            })
+          }
+          it { is_expected.to create_concat_fragment('nscd+conf.group').with({
+              :content => /auto-propagate/
+            })
+          }
+        end
+      end
+    end
   end
 end

--- a/spec/classes/hosts_spec.rb
+++ b/spec/classes/hosts_spec.rb
@@ -1,28 +1,28 @@
 require 'spec_helper'
 
 describe 'nscd::hosts' do
-  let(:facts) {{
-    :fqdn => 'test.host.net',
-    :hardwaremodel => 'x86_64',
-    :operatingsystem => 'RedHat',
-    :lsbmajdistrelease => '7',
-    :apache_version => '2.4',
-    :grub_version => '0.9',
-    :uid_min => '500'
-  }}
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
 
-  it { should create_class('nscd') }
-  it { should create_class('nscd::hosts') }
+        it { is_expected.to create_class('nscd') }
+        it { is_expected.to create_class('nscd::hosts') }
 
-  context 'base' do
-    it { should compile.with_all_deps }
-    it { should create_concat_fragment('nscd+conf.hosts').with({
-        :content => /enable-cache\s+hosts\s+yes/
-      })
-    }
-    it { should create_concat_fragment('nscd+conf.hosts').without({
-        :content => /auto-propagate/
-      })
-    }
+        context 'base' do
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_concat_fragment('nscd+conf.hosts').with({
+              :content => /enable-cache\s+hosts\s+yes/
+            })
+          }
+          it { is_expected.to create_concat_fragment('nscd+conf.hosts').without({
+              :content => /auto-propagate/
+            })
+          }
+        end
+      end
+    end
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,31 +1,31 @@
 require 'spec_helper'
 
 describe 'nscd' do
-  let(:facts) {{
-    :fqdn => 'test.host.net',
-    :hardwaremodel => 'x86_64',
-    :operatingsystem => 'RedHat',
-    :lsbmajdistrelease => '7',
-    :apache_version => '2.4',
-    :grub_version => '0.9',
-    :uid_min => '500'
-  }}
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
 
-  it { should create_class('nscd') }
+        it { is_expected.to create_class('nscd') }
 
-  context 'base' do
-    it { should compile.with_all_deps }
-    it { should create_class('openldap::pam') }
-    it { should create_class('nscd::passwd') }
-    it { should create_class('nscd::group') }
-    it { should create_class('nscd::services') }
-    it { should_not create_class('nscd::hosts') }
-    it { should create_concat_fragment('nscd+conf.global').with({ :content => /paranoia\s+no/ }) }
+        context 'base' do
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('openldap::pam') }
+          it { is_expected.to create_class('nscd::passwd') }
+          it { is_expected.to create_class('nscd::group') }
+          it { is_expected.to create_class('nscd::services') }
+          it { is_expected.not_to create_class('nscd::hosts') }
+          it { is_expected.to create_concat_fragment('nscd+conf.global').with({ :content => /paranoia\s+no/ }) }
+        end
+
+        context 'enable_hosts' do
+          let(:params) {{ :enable_caches => ['passwd','group','services','hosts' ] }}
+          it { is_expected.to create_class('nscd::hosts') }
+        end
+
+      end
+    end
   end
-
-  context 'enable_hosts' do
-    let(:params) {{ :enable_caches => ['passwd','group','services','hosts' ] }}
-    it { should create_class('nscd::hosts') }
-  end
-
 end

--- a/spec/classes/passwd_spec.rb
+++ b/spec/classes/passwd_spec.rb
@@ -1,28 +1,28 @@
 require 'spec_helper'
 
 describe 'nscd::passwd' do
-  let(:facts) {{
-    :fqdn => 'test.host.net',
-    :hardwaremodel => 'x86_64',
-    :operatingsystem => 'RedHat',
-    :lsbmajdistrelease => '7',
-    :apache_version => '2.4',
-    :grub_version => '0.9',
-    :uid_min => '500'
-  }}
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
 
-  it { should create_class('nscd') }
-  it { should create_class('nscd::passwd') }
+        it { is_expected.to create_class('nscd') }
+        it { is_expected.to create_class('nscd::passwd') }
 
-  context 'base' do
-    it { should compile.with_all_deps }
-    it { should create_concat_fragment('nscd+conf.passwd').with({
-        :content => /enable-cache\s+passwd\s+yes/
-      })
-    }
-    it { should create_concat_fragment('nscd+conf.passwd').with({
-        :content => /auto-propagate/
-      })
-    }
+        context 'base' do
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_concat_fragment('nscd+conf.passwd').with({
+              :content => /enable-cache\s+passwd\s+yes/
+            })
+          }
+          it { is_expected.to create_concat_fragment('nscd+conf.passwd').with({
+              :content => /auto-propagate/
+            })
+          }
+        end
+      end
+    end
   end
 end

--- a/spec/classes/services_spec.rb
+++ b/spec/classes/services_spec.rb
@@ -1,28 +1,28 @@
 require 'spec_helper'
 
 describe 'nscd::services' do
-  let(:facts) {{
-    :fqdn => 'test.host.net',
-    :hardwaremodel => 'x86_64',
-    :operatingsystem => 'RedHat',
-    :lsbmajdistrelease => '7',
-    :apache_version => '2.4',
-    :grub_version => '0.9',
-    :uid_min => '500'
-  }}
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
 
-  it { should create_class('nscd') }
-  it { should create_class('nscd::services') }
+        it { is_expected.to create_class('nscd') }
+        it { is_expected.to create_class('nscd::services') }
 
-  context 'base' do
-    it { should compile.with_all_deps }
-    it { should create_concat_fragment('nscd+conf.services').with({
-        :content => /enable-cache\s+services\s+yes/
-      })
-    }
-    it { should create_concat_fragment('nscd+conf.services').without({
-        :content => /auto-propagate/
-      })
-    }
+        context 'base' do
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_concat_fragment('nscd+conf.services').with({
+              :content => /enable-cache\s+services\s+yes/
+            })
+          }
+          it { is_expected.to create_concat_fragment('nscd+conf.services').without({
+              :content => /auto-propagate/
+            })
+          }
+        end
+      end
+    end
   end
 end

--- a/spec/fixtures/hieradata/default.yaml
+++ b/spec/fixtures/hieradata/default.yaml
@@ -10,3 +10,6 @@ ldap::uri :
 client_nets :
   - 1.2.3.4
   - 5.6.7.8
+
+use_sssd: false
+use_nscd: true

--- a/spec/fixtures/manifests/site.pp
+++ b/spec/fixtures/manifests/site.pp
@@ -1,0 +1,4 @@
+# This file is normally a vestigial artifact whose presence is required by
+# rspec-puppet for direct spec testing (e.g., `rpec spec/classes/xxx_spec.rb`).
+#
+# Please keep this file to assist tools such as rspec and guard.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
-require 'pathname'
-require 'rspec-puppet'
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet'
+require 'simp/rspec-puppet-facts'
+include Simp::RspecPuppetFacts
+
+require 'pathname'
 
 # RSpec Material
 fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
@@ -13,6 +16,12 @@ if Puppet.version < "4.0.0"
   end
 end
 
+
+if !ENV.key?( 'TRUSTED_NODE_DATA' )
+  warn '== WARNING: TRUSTED_NODE_DATA is unset, using TRUSTED_NODE_DATA=yes'
+  ENV['TRUSTED_NODE_DATA']='yes'
+end
+
 default_hiera_config =<<-EOM
 ---
 :backends:
@@ -21,12 +30,47 @@ default_hiera_config =<<-EOM
 :yaml:
   :datadir: "stub"
 :hierarchy:
-  # This is a variable that you can set in your test classes to ensure that the
-  # targeted YAML file gets loaded in the fixtures.
+  - "%{custom_hiera}"
   - "%{spec_title}"
   - "%{module_name}"
   - "default"
 EOM
+
+# This can be used from inside your spec tests to set the testable environment.
+# You can use this to stub out an ENC.
+#
+# Example:
+#
+# context 'in the :foo environment' do
+#   let(:environment){:foo}
+#   ...
+# end
+#
+def set_environment(environment = :production)
+    RSpec.configure { |c| c.default_facts['environment'] = environment.to_s }
+end
+
+# This can be used from inside your spec tests to load custom hieradata within
+# any context.
+#
+# Example:
+#
+# describe 'some::class' do
+#   context 'with version 10' do
+#     let(:hieradata){ "#{class_name}_v10" }
+#     ...
+#   end
+# end
+#
+# Then, create a YAML file at spec/fixtures/hieradata/some__class_v10.yaml.
+#
+# Hiera will use this file as it's base of information stacked on top of
+# 'default.yaml' and <module_name>.yaml per the defaults above.
+#
+# Note: Any colons (:) are replaced with underscores (_) in the class name.
+def set_hieradata(hieradata)
+    RSpec.configure { |c| c.default_facts['custom_hiera'] = hieradata }
+end
 
 if not File.directory?(File.join(fixture_path,'hieradata')) then
   FileUtils.mkdir_p(File.join(fixture_path,'hieradata'))
@@ -36,15 +80,16 @@ if not File.directory?(File.join(fixture_path,'modules',module_name)) then
   FileUtils.mkdir_p(File.join(fixture_path,'modules',module_name))
 end
 
-Dir.chdir(File.join(fixture_path,'modules',module_name)) do
-  ['manifests','templates','lib'].each do |tgt|
-    if not File.symlink?(tgt) then
-      FileUtils.ln_sf("../../../../#{tgt}",tgt)
-    end
-  end
-end
-
 RSpec.configure do |c|
+  # If nothing else...
+  c.default_facts = {
+    :production => {
+      #:fqdn           => 'production.rspec.test.localdomain',
+      :path           => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+      :concat_basedir => '/tmp'
+    }
+  }
+
   c.mock_framework = :rspec
   c.mock_with :mocha
 
@@ -53,19 +98,52 @@ RSpec.configure do |c|
 
   c.hiera_config = File.join(fixture_path,'hieradata','hiera.yaml')
 
-  c.before(:all) do
-# Add fixture lib dirs to LOAD_PATH. Work-around for PUP-3336
-if Puppet.version < "4.0.0"
-  Dir["#{fixture_path}/modules/*/lib"].entries.each do |lib_dir|
-    $LOAD_PATH << lib_dir
-  end
-end
+  # Useless backtrace noise
+  backtrace_exclusion_patterns = [
+    /spec_helper/,
+    /gems/
+  ]
 
+  if c.respond_to?(:backtrace_exclusion_patterns)
+    c.backtrace_exclusion_patterns = backtrace_exclusion_patterns
+  elsif c.respond_to?(:backtrace_clean_patterns)
+    c.backtrace_clean_patterns = backtrace_exclusion_patterns
+  end
+
+  c.before(:all) do
     data = YAML.load(default_hiera_config)
     data[:yaml][:datadir] = File.join(fixture_path, 'hieradata')
+
     File.open(c.hiera_config, 'w') do |f|
       f.write data.to_yaml
     end
+  end
+
+  c.before(:each) do
+    @spec_global_env_temp = Dir.mktmpdir('simpspec')
+
+    if defined?(environment)
+      set_environment(environment)
+      FileUtils.mkdir_p(File.join(@spec_global_env_temp,environment.to_s))
+    end
+
+    # ensure the user running these tests has an accessible environmentpath
+    Puppet[:environmentpath] = @spec_global_env_temp
+    Puppet[:user] = Etc.getpwuid(Process.uid).name
+    Puppet[:group] = Etc.getgrgid(Process.gid).name
+
+    # sanitize hieradata
+    if defined?(hieradata)
+      set_hieradata(hieradata.gsub(':','_'))
+    elsif defined?(class_name)
+      set_hieradata(class_name.gsub(':','_'))
+    end
+  end
+
+  c.after(:each) do
+    # clean up the mocked environmentpath
+    FileUtils.rm_rf(@spec_global_env_temp)
+    @spec_global_env_temp = nil
   end
 end
 


### PR DESCRIPTION
This commit replaces all `lsb*` facts with their (package-independent)
`operatingsystem*` counterparts.

Also:
- normalized common static module assets
- created metadata.json
- corrected lint errors
- moved parameter validations to the top of each class
- updated rspec tests to the new `expect` syntax

SIMP-675 #close
SIMP-398 #comment updated `pupmod-simp-nscd`
SIMP-667 #comment updated `pupmod-simp-nscd`
