### PR TITLE
(SIMP-860) Fix malformed RPM .spec file

### DIFF
--- a/build/pupmod-nscd.spec
+++ b/build/pupmod-nscd.spec
@@ -56,7 +56,7 @@ fi
 # Post uninstall stuff
 
 %changelog
-* Mon Feb 29 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-7
+* Mon Feb 29 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-7
 - Missed one 'lsb*' fact.
 
 * Fri Dec 04 2015 Chris Tessmer <chris.tessmer@onyxpoint.com> - 5.0.0-6


### PR DESCRIPTION
(SIMP-860) Fix malformed RPM .spec file

Before this commit, the `%changelog` in `pupmod-nscd.spec` had the
incorrect year (**PROTIP:** use `rpmdev-bumpspec`), causing the the rpm
query in the `simp-rake-helpers` gem to fail with a nil/split error
during simp-core ISO builds.

This patch fixes the `%changelog` by correcting the year from "2015" to
"2016" and thus restores the all-too-delicate order of the universe.

SIMP-857 #comment fixed fatal error in `build/pupmod-nscd.spec`
SIMP-858 #comment fixed fatal error in `build/pupmod-nscd.spec`
SIMP-859 #comment see SIMP-860 for a good example of a fatal .spec error
SIMP-860 #close #comment fixed fatal error in latest `%changelog` year
