### PR TITLE
(SIMP-904) Fixed race condition in startup script

### DIFF
--- a/build/pupmod-nscd.spec
+++ b/build/pupmod-nscd.spec
@@ -1,7 +1,7 @@
 Summary: NSCD Puppet Module
 Name: pupmod-nscd
-Version: 5.0.0
-Release: 7
+Version: 5.0.1
+Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -56,6 +56,10 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Mar 28 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.1-0
+- Fixed a race condition between `service nscd restart` and
+  `service nscd reload`.
+
 * Mon Feb 29 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-7
 - Missed one 'lsb*' fact.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,7 +90,7 @@ class nscd (
     $l_service_command = '/sbin/service'
   }
 
-  $nscd_start_command = "/usr/bin/test -e /var/run/nscd/nscd.pid && ! ${l_service_command} nscd status && /bin/rm -f /var/run/nscd/nscd.pid; ${l_service_command} nscd restart && ${l_service_command} nscd reload"
+  $nscd_start_command = "/usr/bin/test -e /var/run/nscd/nscd.pid && ! ${l_service_command} nscd status && /bin/rm -f /var/run/nscd/nscd.pid; ${l_service_command} nscd restart && /bin/sleep 1 && ${l_service_command} nscd reload"
 
   file { '/etc/nscd.conf':
     owner   => 'root',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-nscd",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "author":  "simp",
   "summary": "manages NSCD",
   "license": "Apache-2.0",
@@ -10,19 +10,19 @@
   "tags": [ "simp", "nscd", "ldap", "caching" ],
   "dependencies": [
     {
-      "name": "puppetlabs-stdlib",
+      "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.0.0"
     },
     {
-      "name": "simp-openldap",
+      "name": "simp/openldap",
       "version_requirement": ">= 4.1.0"
     },
     {
-      "name": "simp-simpcat",
+      "name": "simp/simpcat",
       "version_requirement": ">= 4.0.0"
     },
     {
-      "name": "simp-simplib",
+      "name": "simp/simplib",
       "version_requirement": ">= 1.0.0"
     }
   ],


### PR DESCRIPTION
`service nscd restart` and `service nscd reload` needed a `sleep 1`
between them to prevent a race condition from returning a failure on
reload.

SIMP-904 #comment Fix nscd race condition