### PR TITLE
(SIMP-1450) Update to use new 'simpcat'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-0
+- Updated to use the version of 'simpcat' that does not conflict with
+  'puppetlabs/concat'.
+
 * Mon Mar 28 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.1-0
 - Fixed a race condition between `service nscd restart` and
   `service nscd reload`.

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,3 +1,3 @@
 Requires: pupmod-simp-openldap >= 4.1.0-3
-Requires: pupmod-simp-simpcat >= 4.0.0-0
+Requires: pupmod-simp-simpcat >= 6.0.0-0
 Obsoletes: pupmod-nscd-test >= 0.0.1

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -31,7 +31,7 @@ class nscd::group (
   validate_array_member($auto_propogate,['yes','no'])
 
   $svc_name = 'group'
-  concat_fragment { "nscd+conf.${svc_name}":
+  simpcat_fragment { "nscd+conf.${svc_name}":
     content => template('nscd/nscd.service.erb')
   }
 }

--- a/manifests/hosts.pp
+++ b/manifests/hosts.pp
@@ -29,7 +29,7 @@ class nscd::hosts(
   validate_integer($max_db_size)
 
   $svc_name = 'hosts'
-  concat_fragment { "nscd+conf.${svc_name}":
+  simpcat_fragment { "nscd+conf.${svc_name}":
     content => template('nscd/nscd.service.erb')
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,13 +73,13 @@ class nscd (
     include '::nscd::services'
   }
 
-  concat_build { 'nscd':
+  simpcat_build { 'nscd':
     order   => ['conf.*'],
     target  => '/etc/nscd.conf',
     require => Package['nscd']
   }
 
-  concat_fragment { 'nscd+conf.global':
+  simpcat_fragment { 'nscd+conf.global':
     content => template('nscd/nscd.global.erb')
   }
 
@@ -97,7 +97,7 @@ class nscd (
     group   => 'root',
     mode    => '0640',
     require => [
-      Concat_build['nscd'],
+      Simpcat_build['nscd'],
       Package['nscd']
     ],
     audit   => 'content'

--- a/manifests/passwd.pp
+++ b/manifests/passwd.pp
@@ -32,7 +32,7 @@ class nscd::passwd (
 
   $svc_name = 'passwd'
 
-  concat_fragment { "nscd+conf.${svc_name}":
+  simpcat_fragment { "nscd+conf.${svc_name}":
     content => template('nscd/nscd.service.erb')
   }
 }

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -30,7 +30,7 @@ class nscd::services (
 
   $svc_name = 'services'
 
-  concat_fragment { "nscd+conf.${svc_name}":
+  simpcat_fragment { "nscd+conf.${svc_name}":
     content => template('nscd/nscd.service.erb')
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-nscd",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "author":  "simp",
   "summary": "manages NSCD",
   "license": "Apache-2.0",
@@ -19,7 +19,7 @@
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 4.0.0"
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp/simplib",

--- a/spec/classes/group_spec.rb
+++ b/spec/classes/group_spec.rb
@@ -13,11 +13,11 @@ describe 'nscd::group' do
 
         context 'base' do
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_concat_fragment('nscd+conf.group').with({
+          it { is_expected.to create_simpcat_fragment('nscd+conf.group').with({
               :content => /enable-cache\s+group\s+yes/
             })
           }
-          it { is_expected.to create_concat_fragment('nscd+conf.group').with({
+          it { is_expected.to create_simpcat_fragment('nscd+conf.group').with({
               :content => /auto-propagate/
             })
           }

--- a/spec/classes/hosts_spec.rb
+++ b/spec/classes/hosts_spec.rb
@@ -13,11 +13,11 @@ describe 'nscd::hosts' do
 
         context 'base' do
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_concat_fragment('nscd+conf.hosts').with({
+          it { is_expected.to create_simpcat_fragment('nscd+conf.hosts').with({
               :content => /enable-cache\s+hosts\s+yes/
             })
           }
-          it { is_expected.to create_concat_fragment('nscd+conf.hosts').without({
+          it { is_expected.to create_simpcat_fragment('nscd+conf.hosts').without({
               :content => /auto-propagate/
             })
           }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -17,7 +17,7 @@ describe 'nscd' do
           it { is_expected.to create_class('nscd::group') }
           it { is_expected.to create_class('nscd::services') }
           it { is_expected.not_to create_class('nscd::hosts') }
-          it { is_expected.to create_concat_fragment('nscd+conf.global').with({ :content => /paranoia\s+no/ }) }
+          it { is_expected.to create_simpcat_fragment('nscd+conf.global').with({ :content => /paranoia\s+no/ }) }
         end
 
         context 'enable_hosts' do

--- a/spec/classes/passwd_spec.rb
+++ b/spec/classes/passwd_spec.rb
@@ -13,11 +13,11 @@ describe 'nscd::passwd' do
 
         context 'base' do
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_concat_fragment('nscd+conf.passwd').with({
+          it { is_expected.to create_simpcat_fragment('nscd+conf.passwd').with({
               :content => /enable-cache\s+passwd\s+yes/
             })
           }
-          it { is_expected.to create_concat_fragment('nscd+conf.passwd').with({
+          it { is_expected.to create_simpcat_fragment('nscd+conf.passwd').with({
               :content => /auto-propagate/
             })
           }

--- a/spec/classes/services_spec.rb
+++ b/spec/classes/services_spec.rb
@@ -13,11 +13,11 @@ describe 'nscd::services' do
 
         context 'base' do
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_concat_fragment('nscd+conf.services').with({
+          it { is_expected.to create_simpcat_fragment('nscd+conf.services').with({
               :content => /enable-cache\s+services\s+yes/
             })
           }
-          it { is_expected.to create_concat_fragment('nscd+conf.services').without({
+          it { is_expected.to create_simpcat_fragment('nscd+conf.services').without({
               :content => /auto-propagate/
             })
           }


### PR DESCRIPTION
Updated to use the version of 'simpcat' that does not conflict with
'puppetlabs/concat'.

SIMP-1450 #comment Update to use deconflicted 'simpcat'
SIMP-843 #comment Deconflicted 'nscd'
